### PR TITLE
Update version to 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@modernlogic/react-native-geocoder",
-  "version": "0.6.0+3",
+  "name": "@modern-logic/react-native-geocoder",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@modernlogic/react-native-geocoder",
-      "version": "0.6.0+3",
+      "name": "@modern-logic/react-native-geocoder",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "geolib": "^3.3.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@modernlogic/react-native-geocoder",
-  "version": "0.6.0+7",
+  "name": "@modern-logic/react-native-geocoder",
+  "version": "0.6.1",
   "description": "react native geocoding and reverse geocoding",
   "main": "./dist/commonjs/index.js",
   "scripts": {


### PR DESCRIPTION
- Bumps version to 0.6.1
- Updates name of package to be `modern-logic`, aligning with the name with the npm org name to scope the package
- I'd like to automate deployment to npm, I think it's pretty easy but decided maybe I should hold off since it's so easy to do from the command line locally and it didn't feel like a top priority right now